### PR TITLE
Modification to exception handling

### DIFF
--- a/lib/tackle/consumer.ex
+++ b/lib/tackle/consumer.ex
@@ -80,7 +80,7 @@ defmodule Tackle.Consumer do
         rescue
           e in RuntimeError ->
             delayed_retry(state, payload, retry_count)
-            AMQP.Basic.nack(tag, false, false)
+            AMQP.Basic.nack(state.channel, tag, [multiple: false, requeue: false])
         end
       end
 

--- a/lib/tackle/consumer.ex
+++ b/lib/tackle/consumer.ex
@@ -79,8 +79,8 @@ defmodule Tackle.Consumer do
           AMQP.Basic.ack(state.channel, tag)
         rescue
           e in RuntimeError ->
-            AMQP.Basic.ack(state.channel, tag)
             delayed_retry(state, payload, retry_count)
+            AMQP.Basic.nack(state.channel, tag, [multiple: false, requeue: false])
         end
       end
 

--- a/lib/tackle/consumer.ex
+++ b/lib/tackle/consumer.ex
@@ -80,7 +80,7 @@ defmodule Tackle.Consumer do
         rescue
           e in RuntimeError ->
             delayed_retry(state, payload, retry_count)
-            AMQP.Basic.nack(state.channel, tag, [multiple: false, requeue: false])
+            AMQP.Basic.ack(state.channel, tag)
         end
       end
 

--- a/lib/tackle/consumer.ex
+++ b/lib/tackle/consumer.ex
@@ -79,8 +79,8 @@ defmodule Tackle.Consumer do
           AMQP.Basic.ack(state.channel, tag)
         rescue
           e in RuntimeError ->
-            delayed_retry(state, payload, retry_count)
             AMQP.Basic.ack(state.channel, tag)
+            delayed_retry(state, payload, retry_count)
         end
       end
 

--- a/lib/tackle/consumer.ex
+++ b/lib/tackle/consumer.ex
@@ -80,6 +80,7 @@ defmodule Tackle.Consumer do
         rescue
           e in RuntimeError ->
             delayed_retry(state, payload, retry_count)
+            AMQP.Basic.nack(tag, false, false)
         end
       end
 


### PR DESCRIPTION
After exception in handle_message/1 I added Basic.nack. Unacked messages in rabbitmq queue
won't reach limit (Basic.qos = 10). Reaching limit was blocking consumer for some reason. 