### PR TITLE
Handling consumption failure

### DIFF
--- a/test/integration/broken_consumer_raises_test.exs
+++ b/test/integration/broken_consumer_raises_test.exs
@@ -1,0 +1,46 @@
+defmodule Tackle.BrokenConsumerRaisesTest do
+  use ExSpec
+
+  alias Support
+  alias Support.MessageTrace
+
+  defmodule BrokenConsumer do
+    use Tackle.Consumer,
+      url: "amqp://localhost",
+      exchange: "test-exchange",
+      routing_key: "test-messages",
+      service: "broken-service",
+      retry_delay: 1,
+      retry_limit: 3
+
+    def handle_message(message) do
+      message |> MessageTrace.save("broken-service")
+
+      raise "Raised!"
+    end
+  end
+
+  @publish_options %{
+    url: "amqp://localhost",
+    exchange: "test-exchange",
+    routing_key: "test-messages",
+  }
+
+  setup do
+    MessageTrace.clear("broken-service")
+
+    {:ok, _} = BrokenConsumer.start_link
+
+    :timer.sleep(1000)
+  end
+
+  describe "healthy consumer" do
+    it "receives the message multiple times" do
+      Tackle.publish("Hi!", @publish_options)
+
+      :timer.sleep(5000)
+
+      assert MessageTrace.content("broken-service") == "Hi!Hi!Hi!Hi!"
+    end
+  end
+end

--- a/test/integration/broken_consumer_signals_test.exs
+++ b/test/integration/broken_consumer_signals_test.exs
@@ -1,0 +1,46 @@
+defmodule Tackle.BrokenConsumerSignalsTest do
+  use ExSpec
+
+  alias Support
+  alias Support.MessageTrace
+
+  defmodule BrokenConsumer do
+    use Tackle.Consumer,
+      url: "amqp://localhost",
+      exchange: "test-exchange",
+      routing_key: "test-messages",
+      service: "broken-service",
+      retry_delay: 1,
+      retry_limit: 3
+
+    def handle_message(message) do
+      message |> MessageTrace.save("broken-service")
+
+      Process.exit(self, {:foo, message})
+    end
+  end
+
+  @publish_options %{
+    url: "amqp://localhost",
+    exchange: "test-exchange",
+    routing_key: "test-messages",
+  }
+
+  setup do
+    MessageTrace.clear("broken-service")
+
+    {:ok, _} = BrokenConsumer.start_link
+
+    :timer.sleep(1000)
+  end
+
+  describe "healthy consumer" do
+    it "receives the message multiple times" do
+      Tackle.publish("Hi!", @publish_options)
+
+      :timer.sleep(5000)
+
+      assert MessageTrace.content("broken-service") == "Hi!Hi!Hi!Hi!"
+    end
+  end
+end

--- a/test/integration/broken_consumer_throws_test.exs
+++ b/test/integration/broken_consumer_throws_test.exs
@@ -1,0 +1,46 @@
+defmodule Tackle.BrokenConsumerThrowsTest do
+  use ExSpec
+
+  alias Support
+  alias Support.MessageTrace
+
+  defmodule BrokenConsumer do
+    use Tackle.Consumer,
+      url: "amqp://localhost",
+      exchange: "test-exchange",
+      routing_key: "test-messages",
+      service: "broken-service",
+      retry_delay: 1,
+      retry_limit: 3
+
+    def handle_message(message) do
+      message |> MessageTrace.save("broken-service")
+
+      throw {1, 3, 4}
+    end
+  end
+
+  @publish_options %{
+    url: "amqp://localhost",
+    exchange: "test-exchange",
+    routing_key: "test-messages",
+  }
+
+  setup do
+    MessageTrace.clear("broken-service")
+
+    {:ok, _} = BrokenConsumer.start_link
+
+    :timer.sleep(1000)
+  end
+
+  describe "healthy consumer" do
+    it "receives the message multiple times" do
+      Tackle.publish("Hi!", @publish_options)
+
+      :timer.sleep(5000)
+
+      assert MessageTrace.content("broken-service") == "Hi!Hi!Hi!Hi!"
+    end
+  end
+end

--- a/test/lib/tackle/delivery_handler_test.exs
+++ b/test/lib/tackle/delivery_handler_test.exs
@@ -1,0 +1,48 @@
+defmodule Tackle.DeliveryHandlerTest do
+  use ExSpec
+
+  # This is needed for delivery_handler to be generated.
+  defmodule TestConsumer do
+    use Tackle.Consumer,
+      url: "amqp://localhost",
+      exchange: "test-exchange",
+      routing_key: "test-messages",
+      service: "test-service"
+
+    def handle_message(message) do
+      IO.puts "here"
+    end
+  end
+
+
+  describe "delivery" do
+    it "consume pass" do
+      assert :ok == TestConsumer.delivery_handler(
+        fn -> :ok end, 
+        fn a -> :error end)
+    end
+
+    it "consume generates arithmetic exception" do
+      assert :badarith ==
+        TestConsumer.delivery_handler(fn-> 1/0 end, fn reason -> reason end)
+        |> elem(0)
+    end
+
+    it "consume raises" do
+      assert %RuntimeError{message: "foo"} ==
+        TestConsumer.delivery_handler(fn-> raise "foo" end, fn reason -> reason end)
+        |> elem(0)
+    end
+
+    it "consume throws" do
+      assert {:nocatch, {:error, 12}} ==
+        TestConsumer.delivery_handler(fn-> throw {:error, 12} end, fn reason -> reason end)
+        |> elem(0)
+    end
+
+    it "consume signals" do
+      assert :foo ==
+        TestConsumer.delivery_handler(fn->Process.exit(self, :foo) end, fn reason -> reason end)
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -47,4 +47,5 @@ defmodule Support do
 
 end
 
-ExUnit.start()
+ExUnit.start([trace: true])
+


### PR DESCRIPTION
To the best of my knowledge, this is how all errors during message handling can be handled.
`try do...` cannot get them all.
Will talk about this at 'Show and Tell'