### PR TITLE
Parallel message handling

### DIFF
--- a/lib/tackle/channel.ex
+++ b/lib/tackle/channel.ex
@@ -2,11 +2,14 @@ defmodule Tackle.Channel do
   use AMQP
   require Logger
 
-  def create(connection) do
+  @prefetch_count 1
+
+  def create(connection) do create(connection, @prefetch_count) end
+  def create(connection, nil) do create(connection, @prefetch_count) end
+  def create(connection, prefetch_count) do
     {:ok, channel} = Channel.open(connection)
 
-    # Limit unacknowledged messages to 10
-    Basic.qos(channel, prefetch_count: 10)
+    Basic.qos(channel, prefetch_count: prefetch_count)
 
     channel
   end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Tackle.Mixfile do
 
   def project do
     [app: :tackle,
-     version: "0.0.1",
+     version: "0.1.1",
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/integration/broken_consumer_raises_test.exs
+++ b/test/integration/broken_consumer_raises_test.exs
@@ -9,12 +9,12 @@ defmodule Tackle.BrokenConsumerRaisesTest do
       url: "amqp://localhost",
       exchange: "test-exchange",
       routing_key: "test-messages",
-      service: "broken-service",
+      service: "broken-service-raise",
       retry_delay: 1,
       retry_limit: 3
 
     def handle_message(message) do
-      message |> MessageTrace.save("broken-service")
+      message |> MessageTrace.save("broken-service-raise")
 
       raise "Raised!"
     end
@@ -27,7 +27,7 @@ defmodule Tackle.BrokenConsumerRaisesTest do
   }
 
   setup do
-    MessageTrace.clear("broken-service")
+    MessageTrace.clear("broken-service-raise")
 
     {:ok, _} = BrokenConsumer.start_link
 
@@ -40,7 +40,7 @@ defmodule Tackle.BrokenConsumerRaisesTest do
 
       :timer.sleep(5000)
 
-      assert MessageTrace.content("broken-service") == "Hi!Hi!Hi!Hi!"
+      assert MessageTrace.content("broken-service-raise") == "Hi!Hi!Hi!Hi!"
     end
   end
 end

--- a/test/integration/broken_consumer_signals_test.exs
+++ b/test/integration/broken_consumer_signals_test.exs
@@ -9,12 +9,12 @@ defmodule Tackle.BrokenConsumerSignalsTest do
       url: "amqp://localhost",
       exchange: "test-exchange",
       routing_key: "test-messages",
-      service: "broken-service",
+      service: "broken-service-signal",
       retry_delay: 1,
       retry_limit: 3
 
     def handle_message(message) do
-      message |> MessageTrace.save("broken-service")
+      message |> MessageTrace.save("broken-service-signal")
 
       Process.exit(self, {:foo, message})
     end
@@ -27,7 +27,7 @@ defmodule Tackle.BrokenConsumerSignalsTest do
   }
 
   setup do
-    MessageTrace.clear("broken-service")
+    MessageTrace.clear("broken-service-signal")
 
     {:ok, _} = BrokenConsumer.start_link
 
@@ -40,7 +40,7 @@ defmodule Tackle.BrokenConsumerSignalsTest do
 
       :timer.sleep(5000)
 
-      assert MessageTrace.content("broken-service") == "Hi!Hi!Hi!Hi!"
+      assert MessageTrace.content("broken-service-signal") == "Hi!Hi!Hi!Hi!"
     end
   end
 end

--- a/test/integration/broken_consumer_throws_test.exs
+++ b/test/integration/broken_consumer_throws_test.exs
@@ -9,12 +9,12 @@ defmodule Tackle.BrokenConsumerThrowsTest do
       url: "amqp://localhost",
       exchange: "test-exchange",
       routing_key: "test-messages",
-      service: "broken-service",
+      service: "broken-service-throw",
       retry_delay: 1,
       retry_limit: 3
 
     def handle_message(message) do
-      message |> MessageTrace.save("broken-service")
+      message |> MessageTrace.save("broken-service-throw")
 
       throw {1, 3, 4}
     end
@@ -27,7 +27,7 @@ defmodule Tackle.BrokenConsumerThrowsTest do
   }
 
   setup do
-    MessageTrace.clear("broken-service")
+    MessageTrace.clear("broken-service-throw")
 
     {:ok, _} = BrokenConsumer.start_link
 
@@ -40,7 +40,7 @@ defmodule Tackle.BrokenConsumerThrowsTest do
 
       :timer.sleep(5000)
 
-      assert MessageTrace.content("broken-service") == "Hi!Hi!Hi!Hi!"
+      assert MessageTrace.content("broken-service-throw") == "Hi!Hi!Hi!Hi!"
     end
   end
 end

--- a/test/integration/prefetch_count_2_test.exs
+++ b/test/integration/prefetch_count_2_test.exs
@@ -1,0 +1,65 @@
+defmodule Tackle.ParallelMessageHandling_2_Test do
+  use ExSpec
+
+  alias Support
+  alias Support.MessageTrace
+
+  defmodule TestConsumer do
+    use Tackle.Consumer,
+      url: "amqp://localhost",
+      exchange: "test-prefetch-2-exchange",
+      routing_key: "prefetch",
+      service: "prefetch-count-service",
+      prefetch_count: 2
+
+    def handle_message(message) do
+      "#PID" <> spid = message
+      sup = spid |> String.to_char_list |> :erlang.list_to_pid
+      Task.Supervisor.async_nolink(sup, fn-> :timer.sleep :infinity end)
+      receive do msg -> nil end
+    end
+  end
+
+  @publish_options %{
+    url: "amqp://localhost",
+    exchange: "test-prefetch-2-exchange",
+    routing_key: "prefetch",
+  }
+
+  setup do
+    {:ok, _} = TestConsumer.start_link
+
+    {:ok, sup} = Task.Supervisor.start_link()
+    |> IO.inspect
+
+    :timer.sleep(1000)
+
+    {:ok, [sup: sup]}
+  end
+
+  describe "parallel message handling" do
+    it "handles messages in pairs", context do
+      sup = context[:sup]
+      Tackle.publish(sup |> inspect, @publish_options)
+      Tackle.publish(sup |> inspect, @publish_options)
+      Tackle.publish(sup |> inspect, @publish_options)
+      Tackle.publish(sup |> inspect, @publish_options)
+
+      :timer.sleep(1000)
+
+      assert Task.Supervisor.children(sup) |> Enum.count == 2
+      Task.Supervisor.children(sup)
+      |> Enum.each(fn pid -> Task.Supervisor.terminate_child(sup, pid) end)
+
+      :timer.sleep(1000)
+
+      assert Task.Supervisor.children(sup) |> Enum.count == 2
+      Task.Supervisor.children(sup)
+      |> Enum.each(fn pid -> Task.Supervisor.terminate_child(sup, pid) end)
+
+      :timer.sleep(1000)
+
+      assert Task.Supervisor.children(sup) |> Enum.count == 0
+    end
+  end
+end

--- a/test/integration/prefetch_count_test.exs
+++ b/test/integration/prefetch_count_test.exs
@@ -1,0 +1,61 @@
+defmodule Tackle.ParallelMessageHandling_1_Test do
+  use ExSpec
+
+  alias Support
+  alias Support.MessageTrace
+
+  defmodule TestConsumer do
+    use Tackle.Consumer,
+      url: "amqp://localhost",
+      exchange: "test-prefetch-exchange",
+      routing_key: "prefetch",
+      service: "prefetch-count-service"
+
+    def handle_message(message) do
+      "#PID" <> spid = message
+      sup = spid |> String.to_char_list |> :erlang.list_to_pid
+      Task.Supervisor.async_nolink(sup, fn-> :timer.sleep :infinity end)
+      receive do msg -> nil end
+    end
+  end
+
+  @publish_options %{
+    url: "amqp://localhost",
+    exchange: "test-prefetch-exchange",
+    routing_key: "prefetch",
+  }
+
+  setup do
+    {:ok, _} = TestConsumer.start_link
+
+    {:ok, sup} = Task.Supervisor.start_link()
+
+    :timer.sleep(1000)
+
+    {:ok, [sup: sup]}
+  end
+
+  describe "parallel message handling" do
+    it "handles messages sequentialy", context do
+      sup = context[:sup]
+      Tackle.publish(sup |> inspect, @publish_options)
+      Tackle.publish(sup |> inspect, @publish_options)
+
+      :timer.sleep(1000)
+
+      assert Task.Supervisor.children(sup) |> Enum.count == 1
+      Task.Supervisor.children(sup)
+      |> Enum.each(fn pid -> Task.Supervisor.terminate_child(sup, pid) end)
+
+      :timer.sleep(1000)
+
+      assert Task.Supervisor.children(sup) |> Enum.count == 1
+      Task.Supervisor.children(sup)
+      |> Enum.each(fn pid -> Task.Supervisor.terminate_child(sup, pid) end)
+
+      :timer.sleep(1000)
+
+      assert Task.Supervisor.children(sup) |> Enum.count == 0
+    end
+  end
+end


### PR DESCRIPTION
By setting the `prefetch_count` we can determine how many messages are to be handled concurrently.

Currently messages are handled sequentially.
Though 10 is sent from server, 9 are in the queue waiting for previous one to return from `handle_info`.

Changed default `prefetch_count` from 10 to 1 and preserved sequential handling as default for backward compatibility (not sure if that's the right thing to do).