### PR TITLE
Multiple channels through single connection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,29 @@ The above will pull one message from the `dead_queue_name` and publish it on the
 `test-exchange` exchange with `test-messages` routing key.
 
 To republish multiple messages, use a bigger `count` number.
+
+## Opening multiple channels through the same connection
+
+By default each channel (consumer) opens separate connection to the server.
+
+If you want to reduce number of opened connections from one Elixir application
+to RabbitMQ server, you can map multiple channels to single connection.
+
+Each connection can have name, supplied as optional parameter `connection_id`.
+All consumers that have the same connection name share single connection.
+
+Parameter `connection_id` is optional and if not supplied,
+`connection_id` is set to `:default`.
+Value `:default` has exceptional semantic: all channels with `connection_id`
+set to `:default` use separate connections - one channel per `:default` connection.
+
+#### To use this feature
+
+In consumer specification use `connection_id` parameter:
+```
+defmodule Consumer do
+  use Tackle.Consumer,
+    url: "...",
+    connection_id: :connection_identifier,
+    ...
+```

--- a/lib/tackle.ex
+++ b/lib/tackle.ex
@@ -1,5 +1,18 @@
 defmodule Tackle do
+  use Application
+
   require Logger
+
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    children = [
+      worker(Tackle.Connection, []),
+    ]
+
+    opts = [strategy: :one_for_one, name: Tackle.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
 
   def publish(message, options) do
     url = options[:url]

--- a/lib/tackle/connection.ex
+++ b/lib/tackle/connection.ex
@@ -1,0 +1,87 @@
+defmodule Tackle.Connection do
+  require Logger
+
+  @moduledoc """
+  Holds established connections.
+  Each connection is identifed by name.
+
+  Connection name ':default' is speciall: it is NOT persisted ->
+  each open() call with  :default connection name opens new connection
+  (to preserve current behaviour).
+  """
+
+  def start_link do
+    Agent.start_link(fn -> %{} end, name: __MODULE__)
+  end
+
+  @doc """
+  Examples:
+      open(:default, [])
+
+      open(:foo, [])
+  """
+  def open(name, url) do open_(name, url) end
+
+  @doc """
+  Get a list of opened connections
+  """
+  def get_all do
+    Agent.get(__MODULE__, fn state -> state |> Map.to_list end)
+  end
+
+  defp open_(name=:default, url) do
+    connection = open(url)
+    Logger.info("Opening new connection #{inspect connection} for id: #{name}")
+    connection
+  end
+  defp open_(name, url) do
+    Agent.get(__MODULE__, fn state -> Map.get(state, name) end)
+    |> case do
+      nil ->
+        open_and_persist(name, url)
+      connection ->
+        Logger.info("Fetched existing connection #{inspect connection} for id: #{name}")
+        connection
+        |> validate(name)
+        |> reopen_on_validation_failure(name, url)
+    end
+  end
+
+  defp open_and_persist(name, url) do
+    case open(url) do
+      response = {:ok, connection} ->
+        Agent.update(__MODULE__, fn state -> Map.put(state, name, connection) end)
+        Logger.info("Opening new connection #{inspect connection} for id: #{name}")
+        response
+      error ->
+        Logger.error("Failed to open new connection for id: #{name}: #{error}")
+        error
+    end
+  end
+
+  defp validate(connection, name) do
+    connection |> Map.get(:pid) |> validate_connection_process(connection, name)
+  end
+
+  def reopen_on_validation_failure(state = {:error, _}, name, url) do
+    Logger.warn("Connection validation failed #{inspect state} for id: #{name}")
+    Agent.update(__MODULE__, fn state -> Map.delete(state, name) end)
+    open(name, url)
+  end
+  def reopen_on_validation_failure(connection, _name, _url) do
+    {:ok, connection} end
+
+  defp validate_connection_process(pid, connection, name) when is_pid(pid) do
+    pid |> Process.alive? |> validate_connection_process_rh(connection, name)
+  end
+  defp validate_connection_process(_pid, connection, name) do
+    false |> validate_connection_process_rh(connection, name)
+  end
+
+  defp validate_connection_process_rh(_alive? = true,  connection,  _name) do connection end
+  defp validate_connection_process_rh(_alive? = false, _connection, _name)  do
+    {:error, :no_process}
+  end
+
+  def open(url), do: AMQP.Connection.open(url)
+end

--- a/lib/tackle/consumer.ex
+++ b/lib/tackle/consumer.ex
@@ -18,6 +18,8 @@ defmodule Tackle.Consumer do
 
     prefetch_count = options[:prefetch_count] || @prefetch_count
 
+    connection_id = options[:connection_id] || :default
+
     quote do
       @behaviour Tackle.Consumer.Behaviour
 
@@ -35,8 +37,9 @@ defmodule Tackle.Consumer do
         retry_delay = unquote(retry_delay)
         retry_limit = unquote(retry_limit)
         prefetch_count = unquote(prefetch_count)
+        connection_id  = unquote(connection_id)
 
-        {:ok, connection} = AMQP.Connection.open(url)
+        {:ok, connection} = Tackle.Connection.open(connection_id, url)
         channel = Tackle.Channel.create(connection, prefetch_count)
 
         remote_exchange  = unquote(exchange)

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,9 @@ defmodule Tackle.Mixfile do
      deps: deps]
   end
   def application do
-    [applications: [:logger, :amqp]]
+    [ applications: [:logger, :amqp],
+      mod: {Tackle, []}
+    ]
   end
 
   defp deps do

--- a/test/integration/shared_connections_test.exs
+++ b/test/integration/shared_connections_test.exs
@@ -1,0 +1,102 @@
+defmodule Tackle.SharedConnection.Test do
+  use ExSpec
+
+  defmodule TestConsumer1 do
+    use Tackle.Consumer,
+      url: "amqp://localhost",
+      exchange: "test-multiple-channels-exchange-1",
+      routing_key: "multiple-channels",
+      service: "multiple-channels-service-1",
+      connection_id: :single_connection
+
+    def handle_message(message) do
+      Tackle.SharedConnection.Test.message_handler(message, "consumer_1")
+    end
+  end
+
+  defmodule TestConsumer2 do
+    use Tackle.Consumer,
+      url: "amqp://localhost",
+      exchange: "test-multiple-channels-exchange-2",
+      routing_key: "multiple-channels",
+      service: "multiple-channels-service-2",
+      connection_id: :single_connection
+
+    def handle_message(message) do
+      Tackle.SharedConnection.Test.message_handler(message, "consumer_2")
+    end
+  end
+
+  def message_handler(message, response) do
+    "#PID" <> pid = message
+    client = pid |> String.to_char_list |> :erlang.list_to_pid
+    send(client, response)
+  end
+
+  @publish_options_1 %{
+    url: "amqp://localhost",
+    exchange: "test-multiple-channels-exchange-1",
+    routing_key: "multiple-channels",
+  }
+
+  @publish_options_2 %{
+    url: "amqp://localhost",
+    exchange: "test-multiple-channels-exchange-2",
+    routing_key: "multiple-channels",
+  }
+
+  setup_all do
+    # Forget all opened connections
+    Process.whereis(Tackle.Connection) |> Process.exit(:kill)
+    :timer.sleep(100)
+  end
+
+  describe "shared connection" do
+    it "- reopen consumers", context do
+      {:ok, c1} = TestConsumer1.start_link
+      {:ok, c2} = TestConsumer2.start_link
+
+      # only one connection opend
+      assert Tackle.Connection.get_all() |> Enum.count == 1
+
+      verify_consumer_functionality
+
+      # kill consumers
+      Process.unlink(c1)
+      Process.unlink(c2)
+      Process.exit(c1, :kill)
+      Process.exit(c2, :kill)
+
+      # kill connection process
+      assert Tackle.Connection.get_all() |> Enum.count == 1
+      old_pid = get_all_connections
+      old_pid |> Process.exit(:kill)
+
+      #restart consumers
+      {:ok, _} = TestConsumer1.start_link
+      {:ok, _} = TestConsumer2.start_link
+
+      # new connection process?
+      assert Tackle.Connection.get_all() |> Enum.count == 1
+      new_pid = get_all_connections
+      assert old_pid != new_pid
+
+      verify_consumer_functionality
+    end
+
+    def verify_consumer_functionality do
+      Tackle.publish(self |> inspect, @publish_options_1)
+      Tackle.publish(self |> inspect, @publish_options_2)
+
+      response = rcv() <> rcv()
+      assert String.contains?(response, "consumer_1")
+      assert String.contains?(response, "consumer_2")
+    end
+
+    def get_all_connections do
+      Tackle.Connection.get_all |> Keyword.get(:single_connection) |> Map.get(:pid)
+    end
+
+    def rcv do receive do msg -> msg end end
+  end
+end

--- a/test/lib/tackle/connection_test.exs
+++ b/test/lib/tackle/connection_test.exs
@@ -1,0 +1,31 @@
+defmodule Tackle.ConnectionTest do
+  use ExUnit.Case
+  doctest Tackle.Connection, [import: true]
+
+  setup_all do
+    # Forget all opened connections
+    Process.whereis(Tackle.Connection) |> Process.exit(:kill)
+    :timer.sleep(100)
+  end
+
+
+  test "default connection name returns new process for each call" do
+    pid = get_connection_pid(:default)
+    assert get_connection_pid(:default) != pid
+  end
+
+  test "non default connection name returns same process for each call" do
+    pid = get_connection_pid(:foo)
+    assert get_connection_pid(:foo) == pid
+  end
+
+  test "connection process died -> create new one" do
+    pid = get_connection_pid(:bar)
+    Process.exit(pid, :kill)
+    assert get_connection_pid(:bar) != pid
+  end
+
+  def get_connection_pid(name) do Tackle.Connection.open(name, []) |> get_pid end
+
+  def get_pid({:ok, connection}) do connection |> Map.get(:pid) end
+end


### PR DESCRIPTION
Original 'single channel single connection' semantic preserved as default.
Details in README