### PR TITLE
 Address Elixir 1.4 warning about deps

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Tackle.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
   def application do
     [ applications: [:logger, :amqp],


### PR DESCRIPTION
```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /home/vagrant/box-metrics/deps/watchman/mix.exs:10
```