### PR TITLE
Add start_link/1 to consumer

### DIFF
--- a/lib/tackle/consumer.ex
+++ b/lib/tackle/consumer.ex
@@ -30,6 +30,8 @@ defmodule Tackle.Consumer do
         GenServer.start_link(__MODULE__, {}, name: __MODULE__)
       end
 
+      def start_link(_args), do: start_link()
+
       def init({}) do
         url = unquote(url)
         service = unquote(service)


### PR DESCRIPTION
Adds `start_link/1` to consumer in order to easily use from a supervisor, with the defaults.