### PR TITLE
Fix multiconsumer modules naming

### DIFF
--- a/lib/tackle/multiconsumer.ex
+++ b/lib/tackle/multiconsumer.ex
@@ -26,7 +26,6 @@ defmodule Tackle.Multiconsumer do
 
   defmacro __using__(opts) do
     caller_module = __CALLER__.module
-    service = opts[:service]
 
     #
     # Create a consumer module for all routes
@@ -35,7 +34,7 @@ defmodule Tackle.Multiconsumer do
       Enum.map(opts[:routes], fn route ->
         {_, _, [exchange, routing_key, _]} = route
 
-        module_name = Tackle.Multiconsumer.consumer_module_name(service, exchange, routing_key)
+        module_name = Tackle.Multiconsumer.consumer_module_name(caller_module, exchange, routing_key)
 
         quote do
           defmodule unquote(module_name) do
@@ -70,7 +69,7 @@ defmodule Tackle.Multiconsumer do
           children =
             unquote(opts[:routes])
             |> Enum.map(fn {exchange, routing_key, _} ->
-              Tackle.Multiconsumer.consumer_module_name(service, exchange, routing_key)
+              Tackle.Multiconsumer.consumer_module_name(unquote(caller_module), exchange, routing_key)
             end)
             |> Enum.map(fn consumer -> worker(consumer, []) end)
 
@@ -87,7 +86,7 @@ defmodule Tackle.Multiconsumer do
     consumers ++ [supervisor]
   end
 
-  def consumer_module_name(service, exchange, routing_key) do
-    :"#{service}.#{exchange}.#{routing_key}"
+  def consumer_module_name(caller_module, exchange, routing_key) do
+    :"#{caller_module}.#{exchange}.#{routing_key}"
   end
 end

--- a/test/tackle/multiconsumer_test.exs
+++ b/test/tackle/multiconsumer_test.exs
@@ -27,6 +27,20 @@ defmodule Tackle.MulticonsumerTest do
     end
   end
 
+  test "inspect modules" do
+    defined_consumer_modules = :code.all_loaded()
+                       |> Enum.map(fn {mod, _} -> mod end)
+                       |> Enum.filter(fn module -> String.contains?(Atom.to_string(module), "exchange-1.key1") end)
+                       |> Enum.sort()
+
+    expected_consumer_modules =
+      [:"Elixir.Tackle.MulticonsumerTest.MulticonsumerExampleBeta.exchange-1.key1",
+       :"Elixir.Tackle.MulticonsumerTest.MulticonsumerExample.exchange-1.key1"]
+       |> Enum.sort()
+
+    assert defined_consumer_modules == expected_consumer_modules
+  end
+
   test "successfully starts multiconsumers" do
     import Supervisor.Spec
     opts = [strategy: :one_for_one, name: Front.Supervisor]


### PR DESCRIPTION
The name of individual consumer takes caller module into account