### PR TITLE
Scrub AMQP credentials from connection failure logging

### DIFF
--- a/lib/tackle/connection.ex
+++ b/lib/tackle/connection.ex
@@ -67,6 +67,32 @@ defmodule Tackle.Connection do
 
   def scrub_url(_url), do: "[filtered]"
 
+  # Renders an arbitrary term (typically a connection-open result like
+  # `{:ok, %AMQP.Connection{}}` or `{:error, reason}`) safely for logging, by
+  # stripping AMQP userinfo from its inspected form.
+  #
+  # `reason` terms from a failed connection-open can embed the raw AMQP url -
+  # including credentials - as echoed by `:amqp_uri.parse/2` on a malformed
+  # url (as a binary or a charlist). Because the url is malformed, its
+  # userinfo can legitimately contain unencoded special characters (spaces,
+  # slashes, a stray `@`, even the "other" quote character) - exactly the
+  # kind of thing that made the url unparseable in the first place. A fixed
+  # exclusion set (e.g. "stop at any quote or space") fails open on whichever
+  # character it didn't anticipate, so this instead captures the ACTUAL
+  # delimiter quote (`'` for a charlist, `"` for a binary/`~c"..."`)
+  # immediately preceding `amqp(s)://`, then only that same quote -
+  # backreferenced - terminates the run (an escaped `\"`/`\'` pair from
+  # `inspect/1` never terminates it either way). Being greedy, it backtracks
+  # to the LAST `@` before that boundary - i.e. the real userinfo/host split,
+  # even if the userinfo itself contains one. It is a no-op for terms with no
+  # such userinfo, so it is safe to apply unconditionally (e.g. to an
+  # already-clean `%AMQP.Connection{}` struct).
+  defp scrub_term(term) do
+    term
+    |> inspect()
+    |> String.replace(~r{(["'])(amqps?://)(?:\\.|(?!\1)[^\\])*@}, "\\1\\2")
+  end
+
   @doc """
   Get a list of opened connections
   """
@@ -76,7 +102,7 @@ defmodule Tackle.Connection do
 
   defp open_(name = :default, url) do
     connection = open_with_name(url, Atom.to_string(name))
-    Logger.info("Opening new connection #{inspect(connection)} for id: #{name}")
+    Logger.info("Opening new connection #{scrub_term(connection)} for id: #{name}")
     connection
   end
 
@@ -87,7 +113,7 @@ defmodule Tackle.Connection do
         open_and_persist(name, url)
 
       connection ->
-        Logger.info("Fetched existing connection #{inspect(connection)} for id: #{name}")
+        Logger.info("Fetched existing connection #{scrub_term(connection)} for id: #{name}")
 
         connection
         |> validate(name)
@@ -99,11 +125,11 @@ defmodule Tackle.Connection do
     case open_with_name(url, Atom.to_string(name)) do
       response = {:ok, connection} ->
         Agent.update(__MODULE__, fn state -> Map.put(state, name, connection) end)
-        Logger.info("Opening new connection #{inspect(connection)} for id: #{name}")
+        Logger.info("Opening new connection #{scrub_term(connection)} for id: #{name}")
         response
 
       error ->
-        Logger.error("Failed to open new connection for id: #{name}: #{error}")
+        Logger.error("Failed to open new connection for id: #{name}: #{scrub_term(error)}")
         error
     end
   end
@@ -113,7 +139,7 @@ defmodule Tackle.Connection do
   end
 
   def reopen_on_validation_failure(state = {:error, _}, name, url) do
-    Logger.warning("Connection validation failed #{inspect(state)} for id: #{name}")
+    Logger.warning("Connection validation failed #{scrub_term(state)} for id: #{name}")
     Agent.update(__MODULE__, fn state -> Map.delete(state, name) end)
     open(name, url)
   end

--- a/lib/tackle/connection.ex
+++ b/lib/tackle/connection.ex
@@ -46,52 +46,74 @@ defmodule Tackle.Connection do
   Returns the given AMQP url with its userinfo component removed, for use in
   log and status output.
 
-  Uses a whitelist rather than blanking individual fields. A well-formed
-  `amqp`/`amqps` url (non-nil host) is rebuilt from only its scheme/host/port/path,
-  keeping host, port and vhost while dropping userinfo. Anything else - a nil
-  host, an unexpected scheme, a schemeless string, or non-binary input - is
-  replaced wholesale with a placeholder, since userinfo could otherwise survive
-  in another parsed field.
+  Fails closed: this only ever returns a rebuilt `scheme://host:port/path`
+  when the parse is unambiguous and no userinfo can possibly have survived
+  into another field. A well-formed url has any credentials captured
+  entirely into `URI.parse/1`'s `:userinfo` field, which is dropped when
+  rebuilding. But `URI.parse/1` splits userinfo from host on the *last*
+  `@`, using a fairly permissive definition of "host" - an unescaped `/` in
+  the password (common with base64 secrets) makes it stop consuming at that
+  `/` instead, so `:userinfo` comes back `nil` while credential fragments
+  spill into `:host`/`:path` instead (e.g. `"amqp://user:pa/ss@host"` parses
+  to `host: "user"`, `path: "/ss@host"` - a naive rebuild from those fields
+  would leak "user" and "ss" right back out). So: whenever the raw url
+  contains an `@` at all, a `nil` userinfo means the parse is ambiguous, not
+  credential-free, and this returns the placeholder instead of guessing.
+  Anything else non-canonical - a nil host, an unexpected scheme, a
+  schemeless string, non-binary input, or (belt and suspenders) an `@`
+  surviving into the rebuilt string - is also replaced wholesale. Losing
+  host/vhost on a malformed url is an acceptable cost; leaking is not.
   """
   def scrub_url(url) when is_binary(url) do
-    case URI.parse(url) do
-      %URI{host: host, scheme: scheme} = uri
-      when is_binary(host) and scheme in ["amqp", "amqps"] ->
+    uri = URI.parse(url)
+
+    with true <- is_binary(uri.host),
+         true <- uri.scheme in ["amqp", "amqps"],
+         true <- credentials_fully_captured?(url, uri.userinfo) do
+      rebuilt =
         %URI{scheme: uri.scheme, host: uri.host, port: uri.port, path: uri.path}
         |> URI.to_string()
 
-      _ ->
-        "[filtered]"
+      if String.contains?(rebuilt, "@"), do: "[filtered]", else: rebuilt
+    else
+      _ -> "[filtered]"
     end
   end
 
   def scrub_url(_url), do: "[filtered]"
 
-  # Renders an arbitrary term (typically a connection-open result like
-  # `{:ok, %AMQP.Connection{}}` or `{:error, reason}`) safely for logging, by
-  # stripping AMQP userinfo from its inspected form.
-  #
-  # `reason` terms from a failed connection-open can embed the raw AMQP url -
-  # including credentials - as echoed by `:amqp_uri.parse/2` on a malformed
-  # url (as a binary or a charlist). Because the url is malformed, its
-  # userinfo can legitimately contain unencoded special characters (spaces,
-  # slashes, a stray `@`, even the "other" quote character) - exactly the
-  # kind of thing that made the url unparseable in the first place. A fixed
-  # exclusion set (e.g. "stop at any quote or space") fails open on whichever
-  # character it didn't anticipate, so this instead captures the ACTUAL
-  # delimiter quote (`'` for a charlist, `"` for a binary/`~c"..."`)
-  # immediately preceding `amqp(s)://`, then only that same quote -
-  # backreferenced - terminates the run (an escaped `\"`/`\'` pair from
-  # `inspect/1` never terminates it either way). Being greedy, it backtracks
-  # to the LAST `@` before that boundary - i.e. the real userinfo/host split,
-  # even if the userinfo itself contains one. It is a no-op for terms with no
-  # such userinfo, so it is safe to apply unconditionally (e.g. to an
-  # already-clean `%AMQP.Connection{}` struct).
-  defp scrub_term(term) do
-    term
-    |> inspect()
-    |> String.replace(~r{(["'])(amqps?://)(?:\\.|(?!\1)[^\\])*@}, "\\1\\2")
+  defp credentials_fully_captured?(url, userinfo) do
+    if String.contains?(url, "@") do
+      is_binary(userinfo)
+    else
+      is_nil(userinfo)
+    end
   end
+
+  # Reduces a connection-open (or validation) failure to a coarse, safe
+  # classification for logging - NEVER the raw term.
+  #
+  # A `{:error, reason}` from a failed connection-open can embed the raw
+  # AMQP url - including credentials - deep inside `reason` in more than one
+  # place: `:amqp_uri.parse/2` echoes the malformed url verbatim into a
+  # `:malformed_uri` tuple, and separately scatters a BARE password fragment
+  # (no `amqp://` prefix at all) into an erlang stacktrace argument list via
+  # `:erlang.list_to_integer/1`. There is no fixed set of "safe" positions to
+  # pluck out of that shape - and no regex over its `inspect/1` form can
+  # reliably find every one either, which is exactly how the previous
+  # attempt at this still leaked - so this never descends into tuple
+  # contents beyond the leading tag: it unwraps one `{:error, _}` layer,
+  # then repeatedly takes `elem(0)` of whatever tuple remains until it hits
+  # an atom (or gives up). No binary, charlist, list, or nested tuple ever
+  # reaches the log.
+  defp sanitize_reason({:error, reason}), do: sanitize_reason(reason)
+  defp sanitize_reason(reason) when is_atom(reason), do: reason
+
+  defp sanitize_reason(reason) when is_tuple(reason) and tuple_size(reason) > 0 do
+    reason |> elem(0) |> sanitize_reason()
+  end
+
+  defp sanitize_reason(_reason), do: :connection_error
 
   @doc """
   Get a list of opened connections
@@ -101,9 +123,18 @@ defmodule Tackle.Connection do
   end
 
   defp open_(name = :default, url) do
-    connection = open_with_name(url, Atom.to_string(name))
-    Logger.info("Opening new connection #{scrub_term(connection)} for id: #{name}")
-    connection
+    case open_with_name(url, Atom.to_string(name)) do
+      response = {:ok, connection} ->
+        Logger.info("Opening new connection #{inspect(connection)} for id: #{name}")
+        response
+
+      error ->
+        Logger.error(
+          "Failed to open new connection for id: #{name}, url: #{scrub_url(url)}, reason: #{inspect(sanitize_reason(error))}"
+        )
+
+        error
+    end
   end
 
   defp open_(name, url) do
@@ -113,7 +144,7 @@ defmodule Tackle.Connection do
         open_and_persist(name, url)
 
       connection ->
-        Logger.info("Fetched existing connection #{scrub_term(connection)} for id: #{name}")
+        Logger.info("Fetched existing connection #{inspect(connection)} for id: #{name}")
 
         connection
         |> validate(name)
@@ -125,11 +156,14 @@ defmodule Tackle.Connection do
     case open_with_name(url, Atom.to_string(name)) do
       response = {:ok, connection} ->
         Agent.update(__MODULE__, fn state -> Map.put(state, name, connection) end)
-        Logger.info("Opening new connection #{scrub_term(connection)} for id: #{name}")
+        Logger.info("Opening new connection #{inspect(connection)} for id: #{name}")
         response
 
       error ->
-        Logger.error("Failed to open new connection for id: #{name}: #{scrub_term(error)}")
+        Logger.error(
+          "Failed to open new connection for id: #{name}, url: #{scrub_url(url)}, reason: #{inspect(sanitize_reason(error))}"
+        )
+
         error
     end
   end
@@ -139,7 +173,10 @@ defmodule Tackle.Connection do
   end
 
   def reopen_on_validation_failure(state = {:error, _}, name, url) do
-    Logger.warning("Connection validation failed #{scrub_term(state)} for id: #{name}")
+    Logger.warning(
+      "Connection validation failed for id: #{name}, url: #{scrub_url(url)}, reason: #{inspect(sanitize_reason(state))}"
+    )
+
     Agent.update(__MODULE__, fn state -> Map.delete(state, name) end)
     open(name, url)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Tackle.Mixfile do
   def project do
     [
       app: :tackle,
-      version: "0.3.0",
+      version: "0.4.1",
       elixir: "~> 1.13",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/lib/tackle/connection_test.exs
+++ b/test/lib/tackle/connection_test.exs
@@ -73,101 +73,119 @@ defmodule Tackle.ConnectionTest do
       refute scrubbed =~ "pass"
       refute scrubbed =~ "user"
     end
+
+    test "fails closed on an unescaped '/' in the password instead of misparsing it into the host" do
+      # URI.parse/1 stops consuming userinfo at the first "/", so :host comes
+      # back "user" (part of the username) and the rest of the password
+      # spills into :path as "/mnOP@rabbit:5672/vh" - a rebuild from those
+      # fields alone would produce "amqp://user/mnOP@rabbit:5672/vh",
+      # leaking both the username and a password fragment. RabbitMQ
+      # passwords are frequently base64, whose alphabet includes "/", so
+      # this is a realistic credential, not a contrived one.
+      url = "amqp://user:aB3xYzKq7Lp/mnOP@rabbit:5672/vh"
+
+      assert %URI{host: "user", userinfo: nil} = URI.parse(url)
+
+      scrubbed = Tackle.Connection.scrub_url(url)
+
+      assert scrubbed == "[filtered]"
+      refute scrubbed =~ "aB3xYzKq7Lp"
+      refute scrubbed =~ "user"
+      refute scrubbed =~ "@"
+    end
+
+    test "fails closed on a raw space in the userinfo" do
+      url = "amqp://us er:pa/ss@host:not_a_port/vhost"
+
+      scrubbed = Tackle.Connection.scrub_url(url)
+
+      assert scrubbed == "[filtered]"
+      refute scrubbed =~ "us er"
+      refute scrubbed =~ "pa/ss"
+    end
+
+    test "still redacts (without misparsing) a password containing an embedded '@'" do
+      url = "amqp://user:p@ss@host:not_a_port/vhost"
+
+      scrubbed = Tackle.Connection.scrub_url(url)
+
+      refute scrubbed =~ "p@ss"
+      refute scrubbed =~ "user"
+    end
+
+    test "still redacts (without misparsing) a password containing a double-quote" do
+      url = "amqp://user:pa\"ss@host:not_a_port/vhost"
+
+      scrubbed = Tackle.Connection.scrub_url(url)
+
+      refute scrubbed =~ "pa\"ss"
+      refute scrubbed =~ "user"
+    end
   end
 
   describe "connection-open failure logging" do
-    # A malformed url (illegal port section) makes :amqp_uri.parse echo the
-    # raw url - credentials included - back inside the {:error, reason} term.
-    # See :amqp_uri.parse/2 / uri_parser.erl for the shape of the crash it
-    # embeds.
-    @malformed_credentialed_url "amqp://user:pa/ss@host/vhost"
-
-    # Every open attempt also logs a separate "Connecting to '...'" debug
-    # line (open_with_name/2) built from scrub_url/1 on the *raw input url*,
-    # not from scrub_term/1 on the *error term* - a different helper on a
-    # different value entirely. These tests are about scrub_term, so they
-    # assert against the specific "Opening.../Failed..." line it produces
-    # (via log_line/2), rather than the whole captured log, to stay isolated
-    # from that other code path.
-    test "the :default path (open_/2) scrubs credentials from the error it logs" do
+    # These are the two confirmed leak repros: a RabbitMQ password
+    # containing an unescaped "/" (realistic - base64 secrets include "/")
+    # makes :amqp_uri.parse/2 fail with a reason that embeds the BARE
+    # password fragment with no "amqp://" prefix at all (inside an erlang
+    # stacktrace argument, e.g. `{:erlang, :list_to_integer, ['<fragment>'],
+    # ...}`), so a scheme-anchored scrub over the inspected error term can
+    # never reach it. The fix is to never inspect/interpolate the raw error
+    # term in the first place - these tests assert the FRAGMENT is absent
+    # from the whole captured log, not just that the full password string is
+    # gone (checking only the full literal is how the previous, rejected
+    # attempt passed its tests while still leaking a substring of it).
+    test "the :default path (open_/2) never leaks the password fragment from a malformed uri" do
       log =
         capture_log(fn ->
-          assert {:error, _reason} = Tackle.Connection.open(:default, @malformed_credentialed_url)
+          assert {:error, _reason} =
+                   Tackle.Connection.open(:default, "amqp://user:aB3xYzKq7Lp/mnOP@rabbit:5672/vh")
         end)
 
-      line = log_line(log, "Opening new connection")
-      refute line =~ "pa/ss"
-      assert line =~ "amqp://host/vhost"
+      refute log =~ "aB3xYzKq7Lp"
+
+      line = log_line(log, "Failed to open new connection")
+      assert line =~ "reason: :unable_to_parse_uri"
+      assert line =~ "url: [filtered]"
     end
 
-    test "the open_and_persist/2 error path scrubs credentials and does not raise" do
+    test "the open_and_persist/2 path never leaks the password fragment from a malformed uri" do
       name = :"leak_regression_#{System.unique_integer([:positive])}"
 
       log =
         capture_log(fn ->
-          assert {:error, _reason} = Tackle.Connection.open(name, @malformed_credentialed_url)
+          assert {:error, _reason} =
+                   Tackle.Connection.open(name, "amqp://u:WHOLESECRET/@host/vhost")
         end)
+
+      refute log =~ "WHOLESECRET"
 
       line = log_line(log, "Failed to open new connection")
-      refute line =~ "pa/ss"
-      assert line =~ "amqp://host/vhost"
+      assert line =~ "reason: :unable_to_parse_uri"
+      assert line =~ "url: [filtered]"
     end
 
-    # A naive scrub that stops at the first "special" character in the
-    # userinfo fails open on exactly these two shapes: a raw space, and a
-    # stray "@" inside the credentials. Both are realistic for a malformed
-    # (hence unencoded) url, and both previously either leaked the whole url
-    # (space) or leaked a fragment of the password (embedded "@").
-    test "the :default path scrubs a credentialed url with a space in the userinfo" do
-      url = "amqp://us er:pa/ss@host:not_a_port/vhost"
-
-      log =
-        capture_log(fn ->
-          assert {:error, _reason} = Tackle.Connection.open(:default, url)
-        end)
-
-      line = log_line(log, "Opening new connection")
-      refute line =~ "us er"
-      refute line =~ "pa/ss"
-      assert line =~ "amqp://host:not_a_port/vhost"
-    end
-
-    test "the open_and_persist/2 path scrubs a credentialed url with an embedded '@' in the password" do
-      url = "amqp://user:p@ss@host:not_a_port/vhost"
+    test "reopen_on_validation_failure/3 logs a sanitized reason, not the raw validation term" do
       name = :"leak_regression_#{System.unique_integer([:positive])}"
 
       log =
         capture_log(fn ->
-          assert {:error, _reason} = Tackle.Connection.open(name, url)
+          assert {:ok, connection} =
+                   Tackle.Connection.reopen_on_validation_failure(
+                     {:error, :no_process},
+                     name,
+                     "amqp://rabbitmq:5672"
+                   )
+
+          AMQP.Connection.close(connection)
         end)
 
-      line = log_line(log, "Failed to open new connection")
-      refute line =~ "p@ss"
-      refute line =~ "user:p"
-      assert line =~ "amqp://host:not_a_port/vhost"
+      line = log_line(log, "Connection validation failed")
+      assert line =~ "reason: :no_process"
+      assert line =~ "amqp://rabbitmq:5672"
     end
 
-    # The raw url gets echoed back as a *charlist* (single-quote delimited in
-    # inspect/1's output), so a literal double-quote in the credentials is
-    # not a real terminator - only an unescaped single-quote is. A scrub that
-    # treats "any quote character" as a hard stop, rather than the actual
-    # enclosing delimiter, fails open here exactly like it did on the space
-    # and embedded-"@" cases above.
-    test "the :default path scrubs a credentialed url with a double-quote in the password" do
-      url = "amqp://user:pa\"ss@host:not_a_port/vhost"
-
-      log =
-        capture_log(fn ->
-          assert {:error, _reason} = Tackle.Connection.open(:default, url)
-        end)
-
-      line = log_line(log, "Opening new connection")
-      refute line =~ "pa\"ss"
-      refute line =~ "user:pa"
-      assert line =~ "amqp://host:not_a_port/vhost"
-    end
-
-    test "a non-url-bearing connection error is logged as-is and does not raise" do
+    test "a non-url-bearing connection error logs the scrubbed url and sanitized reason, without raising" do
       name = :"leak_regression_#{System.unique_integer([:positive])}"
 
       log =
@@ -177,8 +195,11 @@ defmodule Tackle.ConnectionTest do
         end)
 
       assert log =~ "Failed to open new connection"
-      assert log =~ ":econnrefused"
+      assert log =~ "reason: :econnrefused"
+      assert log =~ "amqp://127.0.0.1:1/vhost"
       refute log =~ "user:pass@"
+      refute log =~ "user"
+      refute log =~ "pass"
     end
 
     test "a successful connection open still logs a clean, readable struct" do

--- a/test/lib/tackle/connection_test.exs
+++ b/test/lib/tackle/connection_test.exs
@@ -121,6 +121,50 @@ defmodule Tackle.ConnectionTest do
       refute scrubbed =~ "pa\"ss"
       refute scrubbed =~ "user"
     end
+
+    test "redacts a well-formed url with a scheme other than amqp/amqps" do
+      scrubbed = Tackle.Connection.scrub_url("https://user:pass@host:5672/vhost")
+
+      assert scrubbed == "[filtered]"
+      refute scrubbed =~ "pass"
+      refute scrubbed =~ "user"
+    end
+
+    test "redacts non-binary input instead of raising" do
+      assert Tackle.Connection.scrub_url(nil) == "[filtered]"
+      assert Tackle.Connection.scrub_url(123) == "[filtered]"
+      assert Tackle.Connection.scrub_url(%{}) == "[filtered]"
+    end
+  end
+
+  describe "connecting debug log (open/1, open_with_name/2)" do
+    test "open/1 logs only the scrubbed url at debug level, never the raw credentials" do
+      log =
+        capture_log([level: :debug], fn ->
+          Tackle.Connection.open("amqp://leaky_user:leaky_pass@127.0.0.1:1/vh")
+        end)
+
+      line = log_line(log, "Connecting to")
+      assert line =~ "amqp://127.0.0.1:1/vh"
+      refute log =~ "leaky_user"
+      refute log =~ "leaky_pass"
+    end
+
+    test "open_with_name/2 logs only the scrubbed url at debug level, never the raw credentials" do
+      log =
+        capture_log([level: :debug], fn ->
+          Tackle.Connection.open_with_name(
+            "amqp://leaky_user:leaky_pass@127.0.0.1:1/vh",
+            "conn-name"
+          )
+        end)
+
+      line = log_line(log, "Connecting to")
+      assert line =~ "amqp://127.0.0.1:1/vh"
+      assert line =~ "conn-name"
+      refute log =~ "leaky_user"
+      refute log =~ "leaky_pass"
+    end
   end
 
   describe "connection-open failure logging" do

--- a/test/lib/tackle/connection_test.exs
+++ b/test/lib/tackle/connection_test.exs
@@ -1,5 +1,6 @@
 defmodule Tackle.ConnectionTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
   doctest Tackle.Connection, import: true
 
   setup_all do
@@ -30,6 +31,10 @@ defmodule Tackle.ConnectionTest do
 
   def get_pid({:ok, connection}) do
     connection |> Map.get(:pid)
+  end
+
+  defp log_line(log, marker) do
+    log |> String.split("\n") |> Enum.find("", &(&1 =~ marker))
   end
 
   describe "scrub_url/1" do
@@ -67,6 +72,124 @@ defmodule Tackle.ConnectionTest do
       assert scrubbed == "[filtered]"
       refute scrubbed =~ "pass"
       refute scrubbed =~ "user"
+    end
+  end
+
+  describe "connection-open failure logging" do
+    # A malformed url (illegal port section) makes :amqp_uri.parse echo the
+    # raw url - credentials included - back inside the {:error, reason} term.
+    # See :amqp_uri.parse/2 / uri_parser.erl for the shape of the crash it
+    # embeds.
+    @malformed_credentialed_url "amqp://user:pa/ss@host/vhost"
+
+    # Every open attempt also logs a separate "Connecting to '...'" debug
+    # line (open_with_name/2) built from scrub_url/1 on the *raw input url*,
+    # not from scrub_term/1 on the *error term* - a different helper on a
+    # different value entirely. These tests are about scrub_term, so they
+    # assert against the specific "Opening.../Failed..." line it produces
+    # (via log_line/2), rather than the whole captured log, to stay isolated
+    # from that other code path.
+    test "the :default path (open_/2) scrubs credentials from the error it logs" do
+      log =
+        capture_log(fn ->
+          assert {:error, _reason} = Tackle.Connection.open(:default, @malformed_credentialed_url)
+        end)
+
+      line = log_line(log, "Opening new connection")
+      refute line =~ "pa/ss"
+      assert line =~ "amqp://host/vhost"
+    end
+
+    test "the open_and_persist/2 error path scrubs credentials and does not raise" do
+      name = :"leak_regression_#{System.unique_integer([:positive])}"
+
+      log =
+        capture_log(fn ->
+          assert {:error, _reason} = Tackle.Connection.open(name, @malformed_credentialed_url)
+        end)
+
+      line = log_line(log, "Failed to open new connection")
+      refute line =~ "pa/ss"
+      assert line =~ "amqp://host/vhost"
+    end
+
+    # A naive scrub that stops at the first "special" character in the
+    # userinfo fails open on exactly these two shapes: a raw space, and a
+    # stray "@" inside the credentials. Both are realistic for a malformed
+    # (hence unencoded) url, and both previously either leaked the whole url
+    # (space) or leaked a fragment of the password (embedded "@").
+    test "the :default path scrubs a credentialed url with a space in the userinfo" do
+      url = "amqp://us er:pa/ss@host:not_a_port/vhost"
+
+      log =
+        capture_log(fn ->
+          assert {:error, _reason} = Tackle.Connection.open(:default, url)
+        end)
+
+      line = log_line(log, "Opening new connection")
+      refute line =~ "us er"
+      refute line =~ "pa/ss"
+      assert line =~ "amqp://host:not_a_port/vhost"
+    end
+
+    test "the open_and_persist/2 path scrubs a credentialed url with an embedded '@' in the password" do
+      url = "amqp://user:p@ss@host:not_a_port/vhost"
+      name = :"leak_regression_#{System.unique_integer([:positive])}"
+
+      log =
+        capture_log(fn ->
+          assert {:error, _reason} = Tackle.Connection.open(name, url)
+        end)
+
+      line = log_line(log, "Failed to open new connection")
+      refute line =~ "p@ss"
+      refute line =~ "user:p"
+      assert line =~ "amqp://host:not_a_port/vhost"
+    end
+
+    # The raw url gets echoed back as a *charlist* (single-quote delimited in
+    # inspect/1's output), so a literal double-quote in the credentials is
+    # not a real terminator - only an unescaped single-quote is. A scrub that
+    # treats "any quote character" as a hard stop, rather than the actual
+    # enclosing delimiter, fails open here exactly like it did on the space
+    # and embedded-"@" cases above.
+    test "the :default path scrubs a credentialed url with a double-quote in the password" do
+      url = "amqp://user:pa\"ss@host:not_a_port/vhost"
+
+      log =
+        capture_log(fn ->
+          assert {:error, _reason} = Tackle.Connection.open(:default, url)
+        end)
+
+      line = log_line(log, "Opening new connection")
+      refute line =~ "pa\"ss"
+      refute line =~ "user:pa"
+      assert line =~ "amqp://host:not_a_port/vhost"
+    end
+
+    test "a non-url-bearing connection error is logged as-is and does not raise" do
+      name = :"leak_regression_#{System.unique_integer([:positive])}"
+
+      log =
+        capture_log(fn ->
+          assert {:error, :econnrefused} =
+                   Tackle.Connection.open(name, "amqp://user:pass@127.0.0.1:1/vhost")
+        end)
+
+      assert log =~ "Failed to open new connection"
+      assert log =~ ":econnrefused"
+      refute log =~ "user:pass@"
+    end
+
+    test "a successful connection open still logs a clean, readable struct" do
+      log =
+        capture_log(fn ->
+          assert {:ok, connection} = Tackle.Connection.open(:default, "amqp://rabbitmq:5672")
+          AMQP.Connection.close(connection)
+        end)
+
+      assert log =~ "Opening new connection"
+      assert log =~ "%AMQP.Connection{"
     end
   end
 end


### PR DESCRIPTION
On a connection-open failure, the raw error term (which can embed the full AMQP URL with credentials, e.g. echoed back by `:amqp_uri.parse` on a malformed URL) was written to logs unscrubbed, and one of the affected `Logger.error` calls string-interpolated the raw tuple directly, raising `Protocol.UndefinedError` on any connection failure. This scrubs credentials from every connection-open log line in `lib/tackle/connection.ex` and fixes the raise. Targets v0.4.1.